### PR TITLE
Write file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
 test:
 	go test
 .PHONY: test
+
+test-with-writefile:
+	CAPTURE_WRITEFILE=writefile go test
+.POHNY: test-with-writefile
+
+clean:
+	rm -rf writefile
+

--- a/capture.go
+++ b/capture.go
@@ -9,6 +9,19 @@ import (
 	"github.com/podhmo/tenuki/capture"
 )
 
+func NewCaptureTransportWithDefault(t *testing.T, basedir string) *CapturedTransport {
+	ct := &CapturedTransport{T: t}
+	if basedir != "" {
+		ct.Dumper = &capture.FileDumper{
+			BaseDir:      capture.Dir(basedir),
+			DisableCount: !CaptureCountEnabledDefault,
+			Counter:      &globalFileDumpCounter,
+			Prefix:       t.Name(),
+		}
+	}
+	return ct
+}
+
 type CapturedTransport struct {
 	capture.CapturedTransport
 	T *testing.T

--- a/facade.go
+++ b/facade.go
@@ -59,6 +59,16 @@ func New(t *testing.T, options ...func(*Facade)) *Facade {
 	}
 	return f
 }
+func WithoutCapture() func(*Facade) {
+	return func(f *Facade) {
+		f.captureEnabled = false
+	}
+}
+func WithWriteFile(basedir string) func(*Facade) {
+	return func(f *Facade) {
+		f.writeFileBaseDir = basedir
+	}
+}
 
 var noop = func() {}
 

--- a/facade.go
+++ b/facade.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/podhmo/tenuki/capture"
 )
 
 var (
@@ -107,15 +105,7 @@ func (f *Facade) Do(
 	// TODO: not goroutine safe
 	originalTransport := client.Transport
 	if f.captureEnabled {
-		ct := &CapturedTransport{T: f.T}
-		if f.writeFileBaseDir != "" {
-			ct.Dumper = &capture.FileDumper{
-				BaseDir:      capture.Dir(f.writeFileBaseDir),
-				DisableCount: !CaptureCountEnabledDefault,
-				Counter:      &globalFileDumpCounter,
-				Prefix:       t.Name(),
-			}
-		}
+		ct := NewCaptureTransportWithDefault(f.T, f.writeFileBaseDir)
 		ct.Transport = client.Transport
 		client.Transport = ct
 	}

--- a/facade.go
+++ b/facade.go
@@ -16,7 +16,9 @@ import (
 var (
 	CaptureEnabledDefault   bool   = true
 	CaptureWriteFileBaseDir string = ""
-	globalFileDumpCounter   int64  = 0
+
+	CaptureCountEnabledDefault bool  = false
+	globalFileDumpCounter      int64 = 0
 )
 
 func init() {
@@ -108,8 +110,10 @@ func (f *Facade) Do(
 		ct := &CapturedTransport{T: f.T}
 		if f.writeFileBaseDir != "" {
 			ct.Dumper = &capture.FileDumper{
-				BaseDir: capture.Dir(f.writeFileBaseDir),
-				Counter: &globalFileDumpCounter,
+				BaseDir:      capture.Dir(f.writeFileBaseDir),
+				DisableCount: !CaptureCountEnabledDefault,
+				Counter:      &globalFileDumpCounter,
+				Prefix:       t.Name(),
 			}
 		}
 		ct.Transport = client.Transport


### PR DESCRIPTION
fix #7 

```console
$ make test-with-writefile 
CAPTURE_WRITEFILE=writefile go test
2021/03/06 09:44:14 CAPTURE_WRITEFILE is set, so activate the function writing capture output to files
2021/03/06 09:44:14     trace to writefile/records.txt
2021/03/06 09:44:14     trace to writefile/TestDo.req
2021/03/06 09:44:14     trace to writefile/TestDo.res
2021/03/06 09:44:14     trace to writefile/records.txt
2021/03/06 09:44:14     trace to writefile/TestDoHandler.req
2021/03/06 09:44:14     trace to writefile/TestDoHandler.res
2021/03/06 09:44:14     trace to writefile/records.txt
2021/03/06 09:44:14     trace to writefile/TestHandlerRoundTripper.req
2021/03/06 09:44:14     trace to writefile/TestHandlerRoundTripper.res
PASS
ok      github.com/podhmo/tenuki        0.019s
```